### PR TITLE
tested the endpoint DELETE /smurfs both for 200 and for 404, amended …

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ I have also added a simple test that checks for a HTTP response of 200 (OK) when
 
 #### ERRATA CORRIGE
 
-In server/server.js, within POST /smurfs:
+In server/server.js, within the route POST /smurfs:
 
 - add a status of 201 (Created) before sending back the smurf with the response, also send back an object instead of a string or you won't be able to test it.
   The code should look like this:
@@ -343,3 +343,26 @@ In server/server.js, within POST /smurfs:
 Worked in server/tests/server.test.js:
 
 - Added tests for POST /smurfs, both 201 (Created) and 403 (Forbidden)
+
+### testing-server-3
+
+### ERRATA CORRIGE
+
+In server/server.js, within the route DELETE /smurfs:
+
+- return an object instead of a string on a successful operation so it can be tested
+  Your code should look like this:
+
+```js
+if (smurfToBeRemovedExists) {
+  let filteredArray = dataArray.filter(
+    (smurf) => smurf.toLowerCase() !== nameSmurfToBeRemoved.toLowerCase()
+  )
+  dataArray = filteredArray
+  res.send({ name: nameSmurfToBeRemoved })
+}
+```
+
+Worked on server/server/tests/server.test.js:
+
+- Added tests for the route DELETE /smurfs, both 200 (OK) and 404 (Not Found)

--- a/server/server.js
+++ b/server/server.js
@@ -82,7 +82,7 @@ app.post('/smurfs/', (req, res) => {
         (smurf) => smurf.toLowerCase() !== nameSmurfToBeRemoved.toLowerCase()
       )
       dataArray = filteredArray
-      res.send(nameSmurfToBeRemoved)
+      res.send({ name: nameSmurfToBeRemoved })
 
       // If the smurf we want to remove IS NOT in the array then we log a message
       // to the console, we send a HTTP Status response of 404 (NOT FOUND) and

--- a/server/tests/server.test.js
+++ b/server/tests/server.test.js
@@ -67,4 +67,32 @@ describe('Testing the Routes of the server', () => {
     expect(response.body.error).toBeTruthy()
     expect(response.body.error).toMatch(/SmurfDatabase/)
   })
+
+  it('tests that a newly created smurf can be deleted with a response of 200 (OK) and checks the response matches the name of the deleted smurf', async () => {
+    let newSmurf = { name: 'Brainy' }
+
+    const response = await request(api)
+      .post('/smurfs')
+      .send(newSmurf)
+      .expect(201)
+
+    const response2 = await request(api)
+      .delete('/smurfs')
+      .send(newSmurf)
+      .expect(200)
+
+    expect(response2.body.name).toBe('Brainy')
+  })
+
+  it('tests that if you try to delete a non-existent smurf it will respond with a status of 404 (Not Found) and an error message containing the word "SmurfDatabase"', async () => {
+    let nonExistentSmurf = { name: 'NonExistentSmurfName' }
+
+    const response = await request(api)
+      .delete('/smurfs')
+      .send(nonExistentSmurf)
+      .expect(404)
+
+    expect(response.body.error).toBeTruthy()
+    expect(response.body.error).toMatch(/SmurfDatabase/)
+  })
 })


### PR DESCRIPTION
tested the endpoint DELETE /smurfs both for 200 and for 404, amendedserver/server.js delete route to return an object instead of a string so it could be tested